### PR TITLE
Change Arduino.h include to match case for Linux

### DIFF
--- a/mBot-default-program/MeBuzzer.cpp
+++ b/mBot-default-program/MeBuzzer.cpp
@@ -1,5 +1,5 @@
 #include "MeBuzzer.h"
-#include "arduino.h"
+#include <Arduino.h>
 
 #include <avr/io.h>
 #include <stdint.h>


### PR DESCRIPTION
Linux has a case-sensitive filesystem and the header references must match in order to compile.
